### PR TITLE
[Bugfix]: 이메일 인증 중복 처리 개선 및 계정 타입별 이메일 중복 검증 대칭화 (#41, #42)

### DIFF
--- a/src/main/java/com/tropical/backend/auth/repository/UserRepository.java
+++ b/src/main/java/com/tropical/backend/auth/repository/UserRepository.java
@@ -173,6 +173,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndUnverified(@Param("email") String email);
 
     /**
+     * 로컬 계정 이메일 중복 확인
+     *
+     * <p>
+     * 로컬 계정끼리만 이메일 중복을 체크합니다.
+     * 소셜 계정과는 별도로 관리하여 같은 이메일의 다중 계정을 허용합니다.
+     * </p>
+     *
+     * @param email 확인할 이메일
+     * @return 로컬 계정 중 해당 이메일이 존재하면 true, 사용 가능하면 false
+     */
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END " +
+           "FROM User u WHERE u.email = :email AND u.status = 'ACTIVE' AND u.accountType = 'LOCAL'")
+    boolean existsByEmailAndActiveAndLocal(@Param("email") String email);
+
+    /**
      * 이메일 인증 완료 여부 확인
      *
      * <p>

--- a/src/main/java/com/tropical/backend/auth/repository/UserRepository.java
+++ b/src/main/java/com/tropical/backend/auth/repository/UserRepository.java
@@ -173,6 +173,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndUnverified(@Param("email") String email);
 
     /**
+     * 이메일 인증 완료 여부 확인
+     *
+     * <p>
+     * 이메일 인증이 이미 완료된 사용자인지 빠르게 확인합니다.
+     * 중복 인증 요청 처리 시 사용됩니다.
+     * </p>
+     *
+     * @param email 확인할 이메일
+     * @return 해당 이메일이 인증 완료된 상태면 true, 아니면 false
+     */
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END " +
+           "FROM User u WHERE u.email = :email AND u.emailVerified = true AND u.status = 'ACTIVE'")
+    boolean existsByEmailAndVerified(@Param("email") String email);
+
+    /**
      * 특정 기간 이후 마지막 로그인한 사용자 목록 조회
      *
      * <p>

--- a/src/main/java/com/tropical/backend/auth/service/UserService.java
+++ b/src/main/java/com/tropical/backend/auth/service/UserService.java
@@ -68,9 +68,15 @@ public class UserService {
         log.info("로컬 계정 생성 시작 - 이메일: {}, 닉네임: {}", email, nickname);
 
         // 이메일 중복 체크 (활성 계정만)
-        if (userRepository.existsByEmailAndActive(email)) {
-            log.warn("이메일 중복 - 이미 존재하는 이메일: {}", email);
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다: " + email);
+        // if (userRepository.existsByEmailAndActive(email)) {
+        //     log.warn("이메일 중복 - 이미 존재하는 이메일: {}", email);
+        //     throw new IllegalArgumentException("이미 사용 중인 이메일입니다: " + email);
+        // }
+
+        // 이메일 중복 체크 (활성화 된 로컬 계정만)
+        if (userRepository.existsByEmailAndActiveAndLocal(email)) {
+            log.warn("로컬 계정 이메일 중복 - 이미 존재하는 로컬 이메일: {}", email);
+            throw new IllegalArgumentException("이미 사용 중인 로컬 계정 이메일입니다: " + email);
         }
 
         // 닉네임 중복 체크 제거 (중복 허용)

--- a/src/main/java/com/tropical/backend/auth/service/UserService.java
+++ b/src/main/java/com/tropical/backend/auth/service/UserService.java
@@ -48,7 +48,6 @@ public class UserService {
     private final SocialAccountRepository socialAccountRepository;
     private final PasswordEncoder passwordEncoder;
 
-
     /**
      * 로컬 계정 사용자 생성
      *
@@ -246,7 +245,7 @@ public class UserService {
      *
      * <p>
      * 로컬 계정의 이메일 인증을 완료 처리합니다.
-     * 이메일 인증 토큰 검증 후 호출되어야 합니다.
+     * 이미 인증된 계정에 대한 중복 요청도 적절히 처리합니다.
      * </p>
      *
      * @param email 인증할 이메일
@@ -256,6 +255,13 @@ public class UserService {
     public boolean verifyUserEmail(String email) {
         log.info("이메일 인증 처리 시작 - 이메일: {}", email);
 
+        // 이미 인증된 사용자 체크
+        if (userRepository.existsByEmailAndVerified(email)) {
+            log.info("이미 인증 완료된 이메일 - 중복 요청 처리: {}", email);
+            return true; // 이미 인증되었으므로 성공으로 처리
+        }
+
+        // 인증 대기 중인 사용자 처리
         Optional<User> userOpt = userRepository.findByEmailAndUnverified(email);
         if (userOpt.isPresent()) {
             User user = userOpt.get();
@@ -266,7 +272,7 @@ public class UserService {
             return true;
         }
 
-        log.warn("이메일 인증 실패 - 인증 대상 사용자 없음: {}", email);
+        log.warn("이메일 인증 실패 - 존재하지 않는 이메일: {}", email);
         return false;
     }
 


### PR DESCRIPTION
## PR 유형 (Type of PR)

* [ ] 기능 (Feature)
* [x] 버그 수정 (Bugfix)
* [x] 기능 개선 (Enhancement)
* [ ] 리팩토링 (Refactoring)
* [ ] 문서 (Docs)
* [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)

* **#41**: 이미 이메일 인증을 완료한 사용자가 인증 링크를 재클릭하는 경우, “실패”가 아닌 "이미 인증된 계정입니다" 로 **관대한 성공 처리(200)** 를 하도록 변경합니다. 또한 **실패/중복 요청**을 로그에서 구분하여 기록합니다.
* **#42**: **로컬 ↔ 소셜** 가입 순서와 무관하게 일관된 결과가 나오도록, **로컬 회원가입 중복 검증을 ‘로컬 자격’에만 한정**하여 **대칭성**을 확보합니다. 소셜만 존재하는 동일 이메일의 경우 로컬 신규 생성(또는 자격 연결)을 허용합니다.

---

## 관련 이슈 (Related Issue)

* Closes #41
* Closes #42

---

## 변경 사항 (Changes)

### 1) 이메일 인증 중복 처리 개선 (#41)

* `UserRepository.existsByEmailAndVerified(email)` 메서드를 추가합니다.
* `UserService.verifyUserEmail(token)` 로직에 **사전 중복 인증 체크**를 추가합니다.

  * 이미 인증된 경우: `INFO  "이미 인증 완료된 이메일 - 중복 요청 처리"` 로깅 후 **`true` 반환**(HTTP 200)으로 처리합니다.
  * 미인증/유효 토큰: 기존 플로우대로 검증 후 인증을 완료합니다.
  * 미인증/무효 토큰: `WARN "유효하지 않은 토큰"` 로깅 후 실패로 처리합니다.
* Controller 응답 메시지를 개선합니다.

  * 중복 요청: `"이미 인증된 계정입니다"` (success=true, nextStep="login")로 응답합니다.
  * 실패: 기존 실패 메시지를 유지합니다.
* 운영 로그 수준을 세분화합니다. 중복은 `INFO`, 실제 실패는 `WARN/ERROR`로 기록합니다.

### 2) 계정 타입별 이메일 중복 검증 대칭화 (#42)

* **로컬 회원가입 중복 검증을 로컬 자격(Local)에만 한정**합니다.

  * 기존: `existsByEmailAndActive(email)`
  * 변경: `existsByEmailAndActiveAndLocal(email)` 또는 `localCredentialRepository.existsByEmail(email)` 을 사용합니다.
* 이에 따라 다음과 같이 동작합니다.

  * **소셜 → 로컬**: 동일 이메일이어도 **로컬 신규 가입**(또는 로컬 자격 연결)을 허용합니다.
  * **로컬 → 소셜**: 기존과 동일하게 허용합니다.
* 트랜잭션 경계 및 예외 처리를 정리합니다.

  * 컨트롤러 레벨의 `@Transactional` 을 제거하고 서비스 레벨에서만 유지합니다.
  * 서비스에서 `ConflictException` 등 도메인 예외를 그대로 throw 합니다.
  * `@ControllerAdvice` 에서 HTTP 409/400으로 매핑하여 응답합니다.
  * 이로써 `UnexpectedRollbackException` 재발을 방지합니다.
* Postman/OpenAPI 문서와 응답 메시지/코드를 표준화에 맞게 반영합니다.

> **스키마 변경은 수행하지 않습니다.** 애플리케이션 레벨 검증만으로 동작하도록 설계했습니다.
> 단, DB에 `users.email` 유니크 인덱스가 존재하는 경우에는 (1) 제거하거나 (2) `(email, account_type)` 복합 유니크로 마이그레이션하는 방안을 검토하시기 바랍니다. 현재 구현은 리포지토리 레벨 검증만으로도 일관되게 동작하도록 구성했습니다.

---

## 스크린샷 (Screenshots) (Optional)

변경 사항이 없습니다.

---

## 테스트 방법 (Test Steps)

### A. 이메일 인증 중복 처리 (#41)

1. 사용자 A로 회원가입을 진행하고 인증 메일을 수신합니다.
2. **첫 번째 클릭**에서 인증이 성공(200)되는지 확인합니다.
3. \*\*두 번째 클릭(중복)\*\*에서 200 응답과 함께 아래 응답이 내려오는지 확인합니다.

   ```json
   { "success": true, "message": "이미 인증된 계정입니다", "nextStep": "login" }
   ```
4. 서버 로그에서 `INFO ... 이미 인증 완료된 이메일 - 중복 요청 처리: user@example.com` 이 기록되는지 확인합니다.

### B. 계정 타입별 이메일 중복 검증 대칭화 (#42)

**사전 상태**: DB에 동일 이메일 `test@example.com` 이 존재하지 않습니다.

1. **소셜 → 로컬** (이전 실패 케이스가 이제 성공해야 합니다)

* 소셜(구글)로 가입을 완료합니다.
* 동일 이메일로 **로컬 회원가입**을 시도합니다.
* **201/200** 성공과 함께 로컬 자격이 생성(또는 로컬 사용자 생성)되는지 확인합니다.

2. **로컬 → 소셜**

* 로컬로 가입을 완료합니다.
* 동일 이메일로 소셜(구글) 로그인을 시도합니다.
* 정상적으로 허용되는지 확인합니다.

3. **로컬 중복 가입 방지**

* 로컬로 이미 가입된 상태에서 동일 이메일로 **로컬 재가입**을 시도합니다.
* **409** 와 `EMAIL_IN_USE` 응답이 내려오는지 확인합니다.

  ```json
  { "success": false, "errorCode": "EMAIL_IN_USE", "message": "이미 사용 중인 로컬 계정 이메일입니다" }
  ```

4. **트랜잭션/예외 확인**

* `/api/auth/signup` 실패 시 `UnexpectedRollbackException` 이 발생하지 않는지 확인합니다.
* GlobalExceptionHandler 가 4xx 로 정상 변환하는지 확인합니다.

---

## 셀프 체크리스트 (Self-Checklist)

* [x] 제목 규칙을 지켰습니다.
* [x] 관련 이슈를 연결했습니다.
* [x] 로컬에서 충분히 테스트했습니다. (중복 인증/대칭성/예외 변환)
* [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
* [x] CI/CD 파이프라인을 통과했습니다.

---

## 리뷰어에게 (To Reviewers)

* **#41**: `verifyUserEmail()` 의 **사전 중복 인증 체크**가 응답과 로그에서 일관적으로 동작하는지 검토 부탁드립니다.
* **#42**: 로컬 중복 검증이 **로컬 자격**에만 국한되어 **로컬↔소셜 가입 순서의 대칭성**이 확보되었는지 확인 부탁드립니다.