### PR TITLE
[Enhance]: 이메일 인증 중복 요청 처리 및 사용자 경험 개선 (#44)

### DIFF
--- a/src/main/java/com/tropical/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/tropical/backend/auth/controller/AuthController.java
@@ -266,6 +266,7 @@ public class AuthController {
      * 이메일로 발송된 인증 링크를 통해 이메일 인증을 완료합니다.
      * 토큰을 검증한 후 사용자의 emailVerified 플래그를 true로 설정하고
      * 인증 완료 시간을 기록합니다.
+     * 인증 상태에 따라 다른 페이지로 리다이렉트합니다.
      * </p>
      *
      * @param token    이메일 인증 토큰
@@ -289,10 +290,15 @@ public class AuthController {
             String email = claims.get("email", String.class);
 
             // 이메일 인증 처리
-            userService.markEmailVerified(userId, email);
+            boolean wasActuallyVerified = userService.markEmailVerified(userId, email);
 
-            log.info("이메일 인증 완료 - 사용자 ID: {}, 이메일: {}", userId, email);
-            response.sendRedirect(frontendBaseUrl + "/verified");
+            if (wasActuallyVerified) {
+                log.info("이메일 인증 완료 - 사용자 ID: {}, 이메일: {}", userId, email);
+                response.sendRedirect(frontendBaseUrl + "/verified?status=success");
+            } else {
+                // 이미 인증된 경우
+                response.sendRedirect(frontendBaseUrl + "/verified?status=already");
+            }
 
         } catch (Exception e) {
             log.warn("이메일 인증 실패 - 토큰: {}, 사유: {}", token, e.getMessage());

--- a/src/main/java/com/tropical/backend/auth/service/UserService.java
+++ b/src/main/java/com/tropical/backend/auth/service/UserService.java
@@ -228,10 +228,11 @@ public class UserService {
      *
      * @param userId 사용자 ID
      * @param email  인증할 이메일 주소
+     * @return 실제 인증 처리가 이루어졌는지 여부 (이미 인증된 경우 false)
      * @throws IllegalArgumentException 사용자를 찾을 수 없거나 이메일이 일치하지 않는 경우
      */
     @Transactional
-    public void markEmailVerified(Long userId, String email) {
+    public boolean markEmailVerified(Long userId, String email) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
@@ -239,11 +240,18 @@ public class UserService {
             throw new IllegalArgumentException("이메일이 일치하지 않습니다.");
         }
 
+        // 이미 인증된 경우 중복 처리 방지
+        if (user.isEmailVerified()) {
+            log.info("이미 인증 완료된 이메일 - 중복 요청 처리: 사용자 ID {}, 이메일: {}", userId, email);
+            return false; // 실제 인증 처리가 이루어지지 않음을 표시
+        }
+
         user.setEmailVerified(true);
         user.setEmailVerifiedAt(LocalDateTime.now());
         userRepository.save(user);
 
         log.info("이메일 인증 완료 처리 - 사용자 ID: {}, 이메일: {}", userId, email);
+        return true; // 실제 인증 처리가 이루어짐을 표시
     }
 
     /**


### PR DESCRIPTION
## PR 유형 (Type of PR)

* [ ] 기능 (Feature)
* [ ] 버그 수정 (Bugfix)
* [x] 기능 개선 (Enhancement)
* [ ] 리팩토링 (Refactoring)
* [ ] 문서 (Docs)
* [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)

이메일 인증 링크를 **여러 번 클릭**해도 사용자에게 **명확한 피드백**이 전달되도록 백엔드와 리다이렉트 로직을 개선합니다.

* **신규 인증**: `/verified?status=success` 로 리다이렉트
* **이미 인증됨**: `/verified?status=already` 로 리다이렉트
  또한 **중복 클릭 시 불필요한 로그**가 반복 출력되는 문제를 줄이기 위해 **조건부 로깅**을 적용합니다.

---

## 관련 이슈 (Related Issue)

* Closes #44

---

## 변경 사항 (Changes)

1. **UserService**

   * `markEmailVerified(String token)` 반환 타입을 `boolean` 으로 변경합니다.

     * `true` → 이번 요청으로 **새로 인증 완료**
     * `false` → 이미 인증된 상태로 **추가 변경 없음**
   * 이미 인증된 사용자는 **DB 업데이트/불필요한 save 호출 없이** 빠르게 반환하도록 가드 로직을 추가합니다.
   * 로깅 개선

     * 신규 인증: `INFO "이메일 인증 완료 처리 - 사용자 ID: {}, 이메일: {}"`
     * 중복 요청: `INFO "이미 인증 완료된 이메일 - 중복 요청 처리: 사용자 ID {}, 이메일: {}"`

2. **AuthController**

   * `verifyEmail()`에서 `markEmailVerified()`의 반환값에 따라 **리다이렉트 URL에 상태 파라미터**를 부여합니다.

     * `true`  → `302 /verified?status=success`
     * `false` → `302 /verified?status=already`
   * 컨트롤러 로깅 메시지를 **상태별로 분기**하여 혼동을 방지합니다.

     * 신규 인증: `INFO "이메일 인증 완료 - 사용자 ID: {}, 이메일: {}"`
     * 이미 인증: `INFO "이메일 인증 중복 요청 - 사용자 ID: {}, 이메일: {}"`

3. **프론트엔드 대응(가이드)**

   * `/verified` 페이지에서 `URLSearchParams.get('status')` 값을 읽어 메시지를 분기합니다.

     * `success` → "이메일 인증이 완료되었습니다!"
     * `already` → "이미 인증된 계정입니다."
   * (선택) 버튼 스타일 차등(성공=파란색, 이미 인증=회색)

> **하위 호환성**: 기존 인증 링크/흐름은 그대로 동작합니다. 프론트가 파라미터 분기를 아직 적용하지 않아도 `/verified`로 이동하는 기존 UX는 유지됩니다.

---

## 스크린샷 (Screenshots) (Optional)

* (예상) `/verified?status=success` : 성공 메시지 + 파란색 로그인 버튼
* (예상) `/verified?status=already` : 정보 메시지 + 회색 로그인 버튼

---

## 테스트 방법 (Test Steps)

1. **신규 인증 흐름**

   1. 로컬 회원가입 후 이메일 인증 링크 최초 클릭
   2. 서버 로그에 `이메일 인증 완료 처리 …` 및 컨트롤러 `이메일 인증 완료 …`가 출력되는지 확인
   3. 브라우저가 **`/verified?status=success`** 로 리다이렉트되는지 확인

2. **중복 클릭 흐름**

   1. 동일 인증 링크를 다시 클릭
   2. 서버 로그에 `이미 인증 완료된 이메일 - 중복 요청 처리 …` 및 컨트롤러 `이메일 인증 중복 요청 …`가 출력되는지 확인
   3. 브라우저가 **`/verified?status=already`** 로 리다이렉트되는지 확인
   4. (옵션) Hibernate `update user` 쿼리가 **재차 실행되지 않는지** 확인

3. **에러/만료 링크(있다면)**

   * 만료/무효 토큰일 때 기존 실패 응답/리다이렉트가 정상 유지되는지 확인

---

## 셀프 체크리스트 (Self-Checklist)

* [x] 제목 규칙을 지켰습니다.
* [x] 관련 이슈를 연결했습니다.
* [x] 로컬에서 충분히 테스트했습니다. (신규/중복 클릭 케이스)
* [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
* [x] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)

* 서비스의 `markEmailVerified()`가 **idempotent** 하게 동작하는지(중복 클릭 시 DB 업데이트/불필요 save 미발생) 검토 부탁합니다.
* 컨트롤러의 **상태별 로깅/리다이렉트 분기**가 요구사항(#44)에 충분한지 확인 부탁합니다.
* 프론트엔드에서 `/verified?status=…` 파라미터를 활용한 메시지 분기 적용 여부를 추후 체크 예정입니다.