### PR TITLE
[Refactor]: 연도 범위 정책 중앙화 및 HttpOnly 쿠키 기반 인증 고도화 (#89, #90)

### DIFF
--- a/src/main/java/com/tropical/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/tropical/backend/auth/controller/AuthController.java
@@ -603,17 +603,24 @@ public class AuthController {
      * 만료된 Access Token을 Refresh Token을 사용하여 갱신합니다.
      * Refresh Token의 유효성을 검증한 후 새로운 Access Token을 발급하며,
      * 응답과 함께 쿠키도 업데이트합니다.
+     * HttpOnly 쿠키 기반 인증을 지원하여 보안성을 향상시켰습니다.
      * </p>
      *
-     * @param refreshTokenRequest Refresh Token 정보
-     * @param response            HTTP 응답 객체 (쿠키 업데이트용)
+     * @param refreshTokenRequest    Refresh Token 정보 (Body) - 하위 호환성
+     * @param refreshTokenFromCookie 쿠키에서 자동으로 읽어온 Refresh Token (우선순위)
+     * @param response               HTTP 응답 객체 (쿠키 업데이트용)
      * @return 새로운 Access Token
      */
     @PostMapping("/token/refresh")
-    public ResponseEntity<?> refreshToken(@RequestBody Map<String, String> refreshTokenRequest,
+    public ResponseEntity<?> refreshToken(@RequestBody(required = false) Map<String, String> refreshTokenRequest,
+                                          @CookieValue(name = "REFRESH_TOKEN", required = false) String refreshTokenFromCookie,
                                           HttpServletResponse response) {
 
-        String refreshToken = refreshTokenRequest.get("refreshToken");
+        // 쿠키 우선, Body 폴백 방식 (하위 호환성 유지)
+        String refreshToken = refreshTokenFromCookie;
+        if (refreshToken == null && refreshTokenRequest != null) {
+            refreshToken = refreshTokenRequest.get("refreshToken");
+        }
 
         if (refreshToken == null || refreshToken.trim().isEmpty()) {
             return ResponseEntity.badRequest().body(Map.of(

--- a/src/main/java/com/tropical/backend/calendar/client/HolidayApiClient.java
+++ b/src/main/java/com/tropical/backend/calendar/client/HolidayApiClient.java
@@ -1,6 +1,7 @@
 package com.tropical.backend.calendar.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.channel.ChannelOption;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,7 +15,9 @@ import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import reactor.util.retry.Retry;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Year;
 
 /**
  * 한국천문연구원 공휴일 API 클라이언트.
@@ -26,60 +29,50 @@ import java.time.Duration;
  *
  * <p>주요 기능:</p>
  * <ul>
- *   <li>월별 공휴일 조회 (getRestDeInfo 엔드포인트)</li>
- *   <li>월별 국경일 조회 (getHoliDeInfo 엔드포인트)</li>
- *   <li>네트워크 레벨(연결/응답) 및 리액티브 체인 이중 타임아웃 설정</li>
- *   <li>일시적 장애 대응을 위한 경량 재시도 메커니즘</li>
- *   <li>입력 파라미터 검증 및 에러 상황 처리</li>
- *   <li>상세 로깅 및 예외 처리</li>
+ *   <li>월별 공휴일 조회 (getRestDeInfo)</li>
+ *   <li>월별 국경일 조회 (getHoliDeInfo)</li>
+ *   <li>네트워크/리액티브 타임아웃 + 경량 재시도</li>
+ *   <li><b>동적 소프트가드</b>: 현재 연도 + aheadYears 초과 시 호출 생략</li>
+ *   <li><b>4xx 무해화</b>: 4xx 응답은 예외 대신 빈 응답 반환</li>
+ *   <li>상세 로깅 및 비즈니스 코드 검증</li>
  * </ul>
  *
- * @author  왕택준
- * @version 0.1
- * @since   2025.09.16
+ * @author 왕택준
+ * @version 0.2
+ * @since 2025.09.16
  */
 @Slf4j
 @Component
 public class HolidayApiClient {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final WebClient webClient;
     private final String apiKey;
     private final int pageNo;
     private final int numOfRows;
+    private final Clock clock;
 
-    /**
-     * HolidayApiClient 생성자.
-     *
-     * <p>
-     * 환경 설정 값들을 주입받아 WebClient를 초기화합니다.
-     * 네트워크 레벨의 연결/응답 타임아웃과 기본 헤더를 설정하여 안정적인 API 연동을 보장합니다.
-     * User-Agent 헤더를 포함하여 일부 공공 API에서 발생할 수 있는 접근 제한을 방지합니다.
-     * </p>
-     *
-     * @param apiBase API 베이스 URL (예: https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService)
-     * @param apiKey 공공데이터포털에서 발급받은 서비스 키 (디코딩된 키 사용 권장)
-     * @param connectTimeoutMs 연결 타임아웃 (밀리초, 기본값: 3000)
-     * @param readTimeoutMs 응답 타임아웃 (밀리초, 기본값: 4000)
-     * @param pageNo API 호출 시 사용할 페이지 번호 (기본값: 1)
-     * @param numOfRows 한 번에 조회할 최대 행 수 (기본값: 100, 월별 특일 수 고려)
-     */
     public HolidayApiClient(
             @Value("${holiday.api-base}") String apiBase,
             @Value("${holiday.api-key}") String apiKey,
             @Value("${holiday.connect-timeout-ms:3000}") int connectTimeoutMs,
             @Value("${holiday.read-timeout-ms:4000}") int readTimeoutMs,
             @Value("${holiday.page-no:1}") int pageNo,
-            @Value("${holiday.num-of-rows:100}") int numOfRows
+            @Value("${holiday.num-of-rows:100}") int numOfRows,
+            Clock clock
     ) {
         this.apiKey = apiKey;
         this.pageNo = pageNo;
         this.numOfRows = numOfRows;
+        this.clock = clock;
 
-        // 1. 네트워크 레벨 타임아웃 설정
+        // 1) 네트워크 레벨 타임아웃
         HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs) // 연결 타임아웃
-                .responseTimeout(Duration.ofMillis(readTimeoutMs));             // 응답 타임아웃 (데이터 수신 전체 시간)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
+                .responseTimeout(Duration.ofMillis(readTimeoutMs));
 
+        // 2) WebClient 기본 설정
         this.webClient = WebClient.builder()
                 .baseUrl(apiBase)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
@@ -99,60 +92,62 @@ public class HolidayApiClient {
      * 조회된 데이터에는 신정, 설날, 어린이날, 현충일, 광복절, 개천절, 한글날, 성탄절 등이 포함됩니다.
      * </p>
      *
-     * @param year 조회할 연도 (1900년 이후, 예: 2025)
+     * @param year  조회할 연도 (1900년 이후, 예: 2025)
      * @param month 조회할 월 (1-12)
      * @return JSON 응답 데이터 (JsonNode), null이 아님을 보장
      * @throws IllegalArgumentException 연도나 월이 유효하지 않은 경우
-     * @throws RuntimeException API 호출 실패 시
+     * @throws RuntimeException         API 호출 실패 시
      */
     public JsonNode fetchRestHolidays(int year, int month) {
         log.debug("공휴일 조회 시작 - year: {}, month: {}", year, month);
         validateParameters(year, month);
+
+        // **동적 소프트가드**: 현재년도 + aheadYears 초과 시 호출 생략
+        if (isBeyondFutureLimit(year)) {
+            log.info("공휴일 조회 생략(소프트가드) - year: {} (최대 허용: {}), month: {}",
+                    year, getMaxAllowedYear(), month);
+            return emptyResponse("getRestDeInfo", year, month);
+        }
+
         return callApi("/getRestDeInfo", year, month);
     }
 
     /**
-     * 월별 국경일을 조회합니다.
+     * 월별 국경일 조회.
      *
-     * <p>
-     * getHoliDeInfo 엔드포인트를 호출하여 국경일 정보를 가져옵니다.
-     * 조회된 데이터에는 3.1절, 제헌절, 광복절, 개천절, 한글날 등의 국경일이 포함됩니다.
-     * </p>
-     *
-     * <p>공휴일과 국경일의 차이:</p>
-     * <ul>
-     *   <li>공휴일(RestDe): 법정 공휴일로 지정되어 쉬는 날</li>
-     *   <li>국경일(HoliDe): 국가적 의미를 가진 기념일 (공휴일이 아닐 수도 있음)</li>
-     * </ul>
-     *
-     * <p>데이터 없음 처리:</p>
-     * <p>해당 월에 국경일이 없는 경우 정상적인 상황으로 간주하여
-     * 적절한 응답 구조를 가진 빈 데이터를 반환합니다.</p>
-     *
-     * @param year 조회할 연도 (1900년 이후)
-     * @param month 조회할 월 (1-12)
-     * @return JSON 응답 데이터 (JsonNode), null이 아님을 보장
-     * @throws IllegalArgumentException 연도나 월이 유효하지 않은 경우
-     * @throws RuntimeException API 호출 실패 시
+     * @param year  1900+
+     * @param month 1-12
      */
     public JsonNode fetchNationalHolidays(int year, int month) {
         log.debug("국경일 조회 시작 - year: {}, month: {}", year, month);
         validateParameters(year, month);
+
+        // **동적 소프트가드**
+        if (isBeyondFutureLimit(year)) {
+            log.info("국경일 조회 생략(소프트가드) - year: {} (최대 허용: {}), month: {}",
+                    year, getMaxAllowedYear(), month);
+            return emptyResponse("getHoliDeInfo", year, month);
+        }
+
         return callApi("/getHoliDeInfo", year, month);
     }
 
     /**
-     * 연도와 월 파라미터의 유효성을 검증합니다.
-     *
-     * <p>
-     * API 호출 전에 입력 파라미터가 올바른 범위에 있는지 확인합니다.
-     * 잘못된 파라미터로 인한 불필요한 API 호출을 방지하고,
-     * 명확한 에러 메시지를 통해 디버깅을 용이하게 합니다.
-     * </p>
-     *
-     * @param year 검증할 연도
-     * @param month 검증할 월
-     * @throws IllegalArgumentException 연도가 1900년 미만이거나 월이 1-12 범위를 벗어난 경우
+     * 현재년도 + TimeConfig.HOLIDAY_AHEAD_YEARS.
+     */
+    private int getMaxAllowedYear() {
+        return Year.now(clock).getValue() + com.tropical.backend.config.TimeConfig.HOLIDAY_AHEAD_YEARS;
+    }
+
+    /**
+     * 연도가 상한을 초과하는지 여부.
+     */
+    private boolean isBeyondFutureLimit(int year) {
+        return year > getMaxAllowedYear();
+    }
+
+    /**
+     * 파라미터 기본 검증.
      */
     private void validateParameters(int year, int month) {
         if (year < 1900) {
@@ -164,30 +159,10 @@ public class HolidayApiClient {
     }
 
     /**
-     * 공통 API 호출 및 응답 처리 메서드.
+     * 공통 호출부.
      *
-     * <p>
-     * 공휴일 API의 공통 파라미터를 설정하고 HTTP GET 요청을 동기 방식으로 수행합니다.
-     * HTTP 에러 및 API 자체 에러 코드(resultCode)를 검증하고, 실패 시 예외를 발생시킵니다.
-     * </p>
-     *
-     * <p>처리 과정:</p>
-     * <ol>
-     *   <li>URI 빌더를 통한 쿼리 파라미터 구성 (서비스 키 자동 인코딩)</li>
-     *   <li>WebClient를 사용한 비동기 HTTP GET 요청</li>
-     *   <li>HTTP 상태 코드 검증 (4xx/5xx 에러 처리)</li>
-     *   <li>JSON 응답 파싱</li>
-     *   <li>일시적 장애에 대한 재시도 (최대 2회, 300ms 간격)</li>
-     *   <li>리액티브 체인 타임아웃 적용 (10초)</li>
-     *   <li>동기 블로킹으로 결과 반환</li>
-     *   <li>비즈니스 레벨 성공 여부 검증</li>
-     * </ol>
-     *
-     * @param path API 엔드포인트 경로 (/getRestDeInfo 또는 /getHoliDeInfo)
-     * @param year 조회할 연도
-     * @param month 조회할 월
-     * @return 파싱된 JSON 응답 (null이 아님을 보장)
-     * @throws RuntimeException 네트워크 오류, 타임아웃, HTTP 에러, API 비즈니스 에러 시
+     * <p><b>4xx 무해화:</b> 4xx 응답은 예외 대신 빈 응답을 반환합니다.</p>
+     * <p>5xx·타임아웃·연결류만 재시도 유지.</p>
      */
     private JsonNode callApi(String path, int year, int month) {
         String monthStr = String.format("%02d", month);
@@ -196,66 +171,58 @@ public class HolidayApiClient {
             JsonNode rootNode = webClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path(path)
-                            .queryParam("serviceKey", apiKey)  // WebClient가 자동으로 URL 인코딩 처리
+                            .queryParam("serviceKey", apiKey)
                             .queryParam("solYear", year)
                             .queryParam("solMonth", monthStr)
-                            .queryParam("_type", "json")      // JSON 응답 형식 지정
-                            .queryParam("pageNo", pageNo)     // 페이지 번호 (설정 가능)
-                            .queryParam("numOfRows", numOfRows) // 최대 행 수 (설정 가능)
+                            .queryParam("_type", "json")
+                            .queryParam("pageNo", pageNo)
+                            .queryParam("numOfRows", numOfRows)
                             .build())
-                    .retrieve()
-                    // HTTP 상태 코드가 4xx 또는 5xx인 경우 처리
-                    .onStatus(
-                            status -> status.isError(),
-                            response -> response.bodyToMono(String.class)
-                                    .flatMap(errorBody -> {
-                                        log.warn("KASI API HTTP 오류 발생 - status: {}, path: {}, year: {}, month: {}, body: {}",
+                    // retrieve().onStatus(...)는 4xx를 성공 흐름으로 바꾸기 어렵다.
+                    // exchangeToMono로 분기 처리하여 4xx는 "빈 응답" 반환.
+                    .exchangeToMono(response -> {
+                        if (response.statusCode().is2xxSuccessful()) {
+                            return response.bodyToMono(JsonNode.class);
+                        }
+                        if (response.statusCode().is4xxClientError()) {
+                            return response.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .map(body -> {
+                                        log.warn("KASI API 4xx 응답 무해화 - status: {}, path: {}, y: {}, m: {}, body: {}",
                                                 response.statusCode(), path, year, month,
-                                                errorBody.length() > 200 ? errorBody.substring(0, 200) + "..." : errorBody);
-                                        return Mono.error(new RuntimeException(
-                                                "KASI API 호출 실패: HTTP " + response.statusCode()
-                                        ));
-                                    })
-                    )
-                    .bodyToMono(JsonNode.class)
-                    // 일시적 장애에 대한 경량 재시도 메커니�m
+                                                body.length() > 200 ? body.substring(0, 200) + "..." : body);
+                                        return emptyResponse(path, year, month);
+                                    });
+                        }
+                        // 5xx는 예외로 전파해서 재시도 타게 함
+                        return response.createException().flatMap(Mono::error);
+                    })
+                    // 재시도: 5xx/Timeout/Connect류만
                     .retryWhen(
                             Retry.fixedDelay(2, Duration.ofMillis(300))
                                     .filter(throwable -> {
-                                        // 재시도할 예외 타입 선별
-                                        String exceptionName = throwable.getClass().getSimpleName();
-                                        boolean shouldRetry = exceptionName.contains("Timeout") ||
-                                                              exceptionName.contains("Connect") ||
-                                                              throwable.getMessage() != null && throwable.getMessage().contains("5");
-
-                                        if (shouldRetry) {
-                                            log.debug("API 호출 재시도 - path: {}, year: {}, month: {}, exception: {}",
-                                                    path, year, month, exceptionName);
+                                        if (throwable instanceof WebClientResponseException ex) {
+                                            // 5xx만 재시도
+                                            return ex.getStatusCode().is5xxServerError();
                                         }
-                                        return shouldRetry;
+                                        String name = throwable.getClass().getSimpleName();
+                                        return name.contains("Timeout") || name.contains("Connect");
                                     })
-                                    .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
-                                        log.warn("API 호출 재시도 한계 초과 - path: {}, year: {}, month: {}, attempts: {}",
-                                                path, year, month, retrySignal.totalRetries() + 1);
-                                        return retrySignal.failure();
-                                    })
+                                    .onRetryExhaustedThrow((spec, signal) -> signal.failure())
                     )
-                    // 리액티브 체인 레벨 타임아웃 (전체 과정 시간 제한)
                     .timeout(Duration.ofSeconds(10))
-                    .block(); // 비동기 결과를 동기적으로 대기
+                    .block();
 
-            // API 응답 내용의 성공 여부 검증
             ensureSuccess(rootNode, path, year, month);
             return rootNode;
 
         } catch (Exception e) {
-            // WebClientResponseException인 경우 HTTP 상태 코드 정보 포함
             if (e instanceof WebClientResponseException webEx) {
-                log.error("API 호출 중 WebClient 예외 발생 - path: {}, year: {}, month: {}, status: {}, error: {}",
+                log.error("API 호출 중 WebClient 예외 - path: {}, year: {}, month: {}, status: {}, error: {}",
                         path, year, month, webEx.getStatusCode(), webEx.getMessage(), e);
                 throw new RuntimeException("공휴일 API(" + path + ") 호출 실패: " + webEx.getStatusCode(), e);
             } else {
-                log.error("API 호출 중 예외 발생 - path: {}, year: {}, month: {}, error: {}",
+                log.error("API 호출 중 예외 - path: {}, year: {}, month: {}, error: {}",
                         path, year, month, e.getMessage(), e);
                 throw new RuntimeException("공휴일 API(" + path + ") 호출에 실패했습니다.", e);
             }
@@ -263,25 +230,14 @@ public class HolidayApiClient {
     }
 
     /**
-     * KASI API 응답의 비즈니스 레벨 성공 여부를 검증합니다.
+     * 응답 비즈니스 성공 여부 검증.
      *
-     * <p>
-     * HTTP 상태 코드가 200이라도, 응답 본문의 resultCode가 성공 코드가 아니면 실패로 간주합니다.
-     * 공공데이터포털 API의 표준 에러 코드 체계를 따라 응답을 검증합니다.
-     * </p>
-     *
-     * <p>주요 resultCode 처리:</p>
+     * <p>resultCode:</p>
      * <ul>
-     *   <li><b>00</b>: 정상 처리 (성공)</li>
-     *   <li><b>03</b>: 데이터 없음 (정상 상황으로 간주, 예외 발생 안함)</li>
-     *   <li><b>기타</b>: 에러 상황으로 간주하여 RuntimeException 발생</li>
+     *   <li>00: 정상</li>
+     *   <li>03: 데이터 없음(정상으로 간주)</li>
+     *   <li>기타: 실패</li>
      * </ul>
-     *
-     * @param rootNode API 응답의 최상위 JsonNode
-     * @param path 호출한 API 경로 (로깅용)
-     * @param year 호출한 연도 (로깅용)
-     * @param month 호출한 월 (로깅용)
-     * @throws RuntimeException 응답이 null이거나 resultCode가 에러 코드인 경우
      */
     private void ensureSuccess(JsonNode rootNode, String path, int year, int month) {
         if (rootNode == null) {
@@ -291,21 +247,52 @@ public class HolidayApiClient {
         JsonNode header = rootNode.path("response").path("header");
         String resultCode = header.path("resultCode").asText(null);
 
-        // 데이터 없음(03)은 정상 상황으로 간주
         if ("03".equals(resultCode)) {
             log.debug("KASI API 데이터 없음(03) - path: {}, year: {}, month: {} (정상 처리)", path, year, month);
-            return; // 예외 없이 통과, 파서에서 빈 목록 처리됨
+            return;
         }
-
-        // 정상(00) 이외의 코드는 에러로 처리
         if (!"00".equals(resultCode)) {
             String resultMsg = header.path("resultMsg").asText("알 수 없는 오류");
-            String errorMessage = String.format("KASI API가 실패 응답을 반환했습니다. (코드: %s, 메시지: %s) [%s %d-%d]",
+            String msg = String.format("KASI API 실패 응답 (코드: %s, 메시지: %s) [%s %d-%d]",
                     resultCode, resultMsg, path, year, month);
-            log.warn(errorMessage);
-            throw new RuntimeException(errorMessage);
+            log.warn(msg);
+            throw new RuntimeException(msg);
         }
 
         log.debug("API 호출 성공 - path: {}, year: {}, month: {}", path, year, month);
+    }
+
+    /**
+     * “빈 목록”을 의미하는 표준 형태의 응답 페이로드 생성.
+     *
+     * <p>
+     * - resultCode는 '03'(데이터 없음)으로 설정<br>
+     * - 파서가 안전하게 빈 배열로 처리 가능하도록 구조 유지
+     * </p>
+     */
+    private JsonNode emptyResponse(String path, int year, int month) {
+        try {
+            String json = """
+                    {
+                      "response": {
+                        "header": { "resultCode": "03", "resultMsg": "NO DATA" },
+                        "body": {
+                          "items": { "item": [] },
+                          "totalCount": 0,
+                          "pageNo": %d,
+                          "numOfRows": %d
+                        }
+                      },
+                      "_meta": { "path": "%s", "year": %d, "month": %d }
+                    }
+                    """.formatted(pageNo, numOfRows, path, year, month);
+            return MAPPER.readTree(json);
+        } catch (Exception e) {
+            // 만약 파싱에 실패하면 최소 구조라도 만들어 반환
+            log.warn("emptyResponse 생성 중 예외: {}", e.getMessage());
+            return MAPPER.createObjectNode()
+                    .putObject("response").putObject("header")
+                    .put("resultCode", "03").put("resultMsg", "NO DATA");
+        }
     }
 }

--- a/src/main/java/com/tropical/backend/calendar/controller/HolidayController.java
+++ b/src/main/java/com/tropical/backend/calendar/controller/HolidayController.java
@@ -45,15 +45,15 @@ import java.util.List;
  *   <li>Swagger/OpenAPI 문서화 지원</li>
  * </ul>
  *
- * @author  왕택준
+ * @author 왕택준
  * @version 1.0
- * @since   2025.09.17
+ * @since 2025.09.17
  */
 @Slf4j
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/holidays")
+@RequestMapping("/api/v1/holidays")
 @Tag(name = "Holiday", description = "공휴일 조회 API")
 public class HolidayController {
 
@@ -77,14 +77,14 @@ public class HolidayController {
      *   <li><b>24절기</b>: 입춘, 하지, 추분, 동지 등</li>
      * </ul>
      *
-     * @param year 조회할 연도 (1900년 이상, 2030년 이하 권장)
+     * @param year  조회할 연도 (1900년 이상, 현재 연도 +5 이하 권장)
      * @param month 조회할 월 (1-12)
      * @return 해당 월의 공휴일 목록 (HolidayDto 배열)
      * @throws IllegalArgumentException 연도나 월이 유효 범위를 벗어난 경우
      */
     @GetMapping("/monthly")
     @Operation(
-            summary = "월별 공휴일 조회", 
+            summary = "월별 공휴일 조회",
             description = "캐시 우선 전략으로 지정된 월의 모든 공휴일, 기념일, 24절기 정보를 조회합니다."
     )
     @ApiResponses({
@@ -93,26 +93,26 @@ public class HolidayController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     public ResponseEntity<List<HolidayResponse>> getMonthlyHolidays(
-            @Parameter(description = "조회할 연도 (1900 이상, 현재 연도 +2 이하)")
+            @Parameter(description = "조회할 연도 (1900 이상, 현재 연도 +5 이하)")
             @RequestParam
-            @YearWithin(min = 1900, aheadYears = 2)
+            @YearWithin(min = 1900)
             int year,
 
             @Parameter(description = "조회할 월 (1-12)", example = "1")
-            @RequestParam 
+            @RequestParam
             @Min(value = 1, message = "월은 1 이상이어야 합니다")
             @Max(value = 12, message = "월은 12 이하여야 합니다")
             int month
     ) {
         log.debug("월별 공휴일 조회 요청 - year: {}, month: {}", year, month);
-        
+
         List<Holiday> holidays = holidayService.getMonthlyHolidays(year, month);
         List<HolidayResponse> response = holidays.stream()
                 .map(HolidayResponse::from)
                 .toList();
-        
+
         log.debug("월별 공휴일 조회 완료 - year: {}, month: {}, 결과 수: {}", year, month, response.size());
-        
+
         return ResponseEntity.ok(response);
     }
 
@@ -168,6 +168,7 @@ public class HolidayController {
 
         return ResponseEntity.ok(response);
     }
+
     /**
      * 월 단위 휴무일 상태를 조회합니다.
      *
@@ -203,7 +204,7 @@ public class HolidayController {
     public ResponseEntity<List<DayOffStatusResponse>> getMonthStatus(
             @Parameter(description = "조회할 연도", example = "2025")
             @RequestParam
-            @YearWithin(min = 1900, aheadYears = 2)
+            @YearWithin(min = 1900)
             int year,
 
             @Parameter(description = "조회할 월 (1-12)", example = "1")

--- a/src/main/java/com/tropical/backend/calendar/service/HolidayService.java
+++ b/src/main/java/com/tropical/backend/calendar/service/HolidayService.java
@@ -7,6 +7,7 @@ import com.tropical.backend.calendar.dto.response.HolidayCheckResponse;
 import com.tropical.backend.calendar.dto.response.HolidayEventResponse;
 import com.tropical.backend.calendar.entity.Holiday;
 import com.tropical.backend.calendar.repository.HolidayRepository;
+import com.tropical.backend.config.TimeConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -391,12 +392,12 @@ public class HolidayService {
     // ===============================
 
     /**
-     * 동적 최대 허용 연도(현재 연도 + 2)를 반환합니다.
+     * 동적 최대 허용 연도(현재 연도 + 5)를 반환합니다.
      *
      * <p>테스트 용이성을 위해 {@link Clock}을 사용합니다.</p>
      */
     private int dynamicMaxYear() {
-        return Year.now(clock).getValue() + 2;
+        return Year.now(clock).getValue() + TimeConfig.HOLIDAY_AHEAD_YEARS;
     }
 
     /**

--- a/src/main/java/com/tropical/backend/common/util/YearWithin.java
+++ b/src/main/java/com/tropical/backend/common/util/YearWithin.java
@@ -22,14 +22,14 @@ import java.lang.annotation.*;
  * null 값에 대한 처리는 별도의 {@code @NotNull} 어노테이션을 조합하여 제어할 수 있습니다.
  * </p>
  *
- * @author  왕택준
+ * @author 왕택준
  * @version 0.1
- * @since   2025.09.17
+ * @since 2025.09.17
  */
 @Documented
-@Target({ ElementType.PARAMETER, ElementType.FIELD })
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = { YearWithinValidator.class })
+@Constraint(validatedBy = {YearWithinValidator.class})
 public @interface YearWithin {
 
     /**
@@ -39,11 +39,16 @@ public @interface YearWithin {
     String message() default "연도는 {min} 이상, 현재 연도 + {aheadYears} 이하이어야 합니다.";
 
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 
-    /** 허용 최소 연도 (기본값: 1900). */
+    /**
+     * 허용 최소 연도 (기본값: 1900).
+     */
     int min() default 1900;
 
-    /** 현재 연도 기준 허용 연도 오차 (aheadYears) (기본값: 2년). */
-    int aheadYears() default 2;
+    /**
+     * 현재 연도 기준 허용 연도 오차 (aheadYears) (기본값: 5년).
+     */
+    int aheadYears() default 5;
 }

--- a/src/main/java/com/tropical/backend/common/util/YearWithinValidator.java
+++ b/src/main/java/com/tropical/backend/common/util/YearWithinValidator.java
@@ -1,5 +1,6 @@
 package com.tropical.backend.common.util;
 
+import com.tropical.backend.config.TimeConfig;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +30,9 @@ import java.time.Year;
  *   <li>테스트 환경에서 시각 고정 가능</li>
  * </ul>
  *
- * @author  왕택준
+ * @author 왕택준
  * @version 0.1
- * @since   2025.09.17
+ * @since 2025.09.17
  */
 @Component
 @RequiredArgsConstructor
@@ -40,7 +41,6 @@ public class YearWithinValidator implements ConstraintValidator<YearWithin, Inte
     private final Clock clock; // TimeConfig에서 주입 (현재 연도 계산용)
 
     private int min;         // 최소 연도 (어노테이션 속성)
-    private int aheadYears;  // 현재 연도로부터 허용할 추가 연도 범위
 
     /**
      * 어노테이션 속성 초기화.
@@ -50,7 +50,6 @@ public class YearWithinValidator implements ConstraintValidator<YearWithin, Inte
     @Override
     public void initialize(YearWithin ann) {
         this.min = ann.min();
-        this.aheadYears = ann.aheadYears();
     }
 
     /**
@@ -58,7 +57,7 @@ public class YearWithinValidator implements ConstraintValidator<YearWithin, Inte
      *
      * <p>
      * - 값이 null인 경우 true (검증 통과)<br>
-     *   → null 허용 여부는 @NotNull 조합으로 별도 처리<br>
+     * → null 허용 여부는 @NotNull 조합으로 별도 처리<br>
      * - 값이 min 이상, (현재연도+aheadYears) 이하인지 확인<br>
      * </p>
      *
@@ -68,8 +67,9 @@ public class YearWithinValidator implements ConstraintValidator<YearWithin, Inte
      */
     @Override
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
-        if (value == null) return true; // null은 허용, 별도 제약 필요 시 @NotNull 사용
-        int max = Year.now(clock).getValue() + aheadYears;
+        if (value == null) return true;
+        // 어노테이션 속성 대신 TimeConfig 상수 직접 사용
+        int max = Year.now(clock).getValue() + TimeConfig.HOLIDAY_AHEAD_YEARS;
         return value >= min && value <= max;
     }
 }

--- a/src/main/java/com/tropical/backend/config/TimeConfig.java
+++ b/src/main/java/com/tropical/backend/config/TimeConfig.java
@@ -23,15 +23,26 @@ import java.time.Clock;
  * <ul>
  *   <li>현재 시각을 서비스/도메인 로직에서 주입식으로 관리</li>
  *   <li>테스트 코드에서 시각 제어 용이</li>
- *   <li>동적 상한 연도 계산 (현재년도+2) 등에 활용</li>
+ *   <li>동적 상한 연도 계산 (현재년도+5) 등에 활용</li>
  * </ul>
  *
- * @author  왕택준
+ * @author 왕택준
  * @version 0.1
- * @since   2025.09.16
+ * @since 2025.09.19
  */
 @Configuration
 public class TimeConfig {
+
+    /**
+     * 공휴일 조회 시 허용되는 최대 미래 연도의 범위.
+     *
+     * <p>
+     * - 과거 연도는 제한하지 않음 (1900년 이상 허용)<br>
+     * - 미래 연도만 제한하여 불필요한 API 호출 및 데이터 부재 에러 방지<br>
+     * - HolidayController, YearWithinValidator 등에서 검증 시 사용됨
+     * </p>
+     */
+    public static final int HOLIDAY_AHEAD_YEARS = 5; // 기본 5년
 
     /**
      * {@link Clock} 빈 등록.


### PR DESCRIPTION
## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [ ] 기능 (Feature)
- [x] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

이번 PR은 두 가지 핵심적인 리팩토링을 통해 시스템의 **안정성**과 **보안**을 대폭 강화합니다. 첫째, 프론트엔드와 백엔드에 분산되어 있던 **공휴일 조회 연도 범위 정책을 중앙에서 관리**하여 일관성을 확보하고 API 오류를 방지합니다. 둘째, 토큰 갱신 로직을 **HttpOnly 쿠키 기반으로 전환**하여 XSS 공격으로부터 Refresh Token을 보호하고, 로컬/소셜 계정의 **인증 플로우를 명확히 분리**하여 시스템의 견고함을 높입니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.  
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #89
- Closes #90

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

### 1. 공휴일 조회 연도 범위 정책 중앙화 및 일관성 확보 (#89)
- **정책 중앙화**: `TimeConfig`에 `HOLIDAY_AHEAD_YEARS` 상수를 추가하여, 조회 가능한 미래 연도 범위를 '5년'으로 중앙에서 관리합니다.
- **백엔드 일관성 적용**: `@YearWithin` 어노테이션, `YearWithinValidator`, `HolidayService`의 연도 검증 로직이 모두 `TimeConfig`의 중앙 정책을 따르도록 수정하여 '마법의 숫자'를 제거하고 유지보수성을 높였습니다.
- **프론트엔드 일관성 적용**: `Calendar.jsx`의 연도 드롭다운 최대 범위를 백엔드 정책과 동일하게 '현재 연도 + 5년'으로 설정하여, 프론트엔드에서 허용하는 연도가 백엔드에서 거부되는 문제를 해결했습니다.

### 2. HttpOnly 쿠키 기반 인증 고도화 (#90)
- **보안 강화**: `AuthController.refreshToken` 메서드가 Request Body 대신 `@CookieValue`를 사용하여 **HttpOnly 쿠키**에서 Refresh Token을 우선적으로 읽도록 변경하여 XSS 공격으로부터 토큰을 보호합니다. (하위 호환성 유지)
- **인증 플로우 명확화**:
    - **로컬 회원가입 (`signup`)**: 회원가입 시 약관 동의를 함께 받아 즉시 온보딩을 완료하고, 이메일 인증을 시작하도록 플로우를 통합했습니다.
    - **로컬 로그인 (`login`)**: 이메일 인증이 완료되지 않은 사용자의 로그인을 차단하는 검증 로직을 추가했습니다.
    - **소셜 온보딩 (`completeSocialOnboarding`)**: 로컬 계정이 이 엔드포인트에 접근하는 것을 차단하여 소셜 계정 전용임을 명확히 했습니다.

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

(백엔드 로직 리팩토링으로 해당 사항 없음)

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

### **1. 연도 범위 정책 검증 (#89)**
1.  **UI 확인**: 캘린더 페이지에서 연도 드롭다운의 최대 연도가 **(현재 연도 + 5년)**인지 확인합니다.
2.  **API 테스트**: Swagger UI에서 `GET /api/v1/holidays/monthly`를 테스트합니다.
    - `year`에 **(현재 연도 + 5년)**을 입력하면 `200 OK` 응답을 받는지 확인합니다.
    - `year`에 **(현재 연도 + 6년)**을 입력하면 `400 Bad Request` 응답을 받는지 확인합니다.

### **2. 인증 플로우 고도화 검증 (#90)**
1.  **HttpOnly 쿠키 기반 토큰 갱신**:
    - 로그인 후 개발자 도구에서 `ACCESS_TOKEN` 쿠키를 삭제하고, 인증이 필요한 API를 호출했을 때, 페이지 새로고침 없이 자동으로 토큰이 갱신되는지 확인합니다.
    - `Network` 탭에서 `/token/refresh` 요청의 `Request Payload`가 비어있는지 확인합니다.
2.  **로컬 회원가입 및 로그인**:
    - `POST /signup`으로 회원가입 후, 이메일 인증을 완료하지 않은 상태에서 `POST /login`을 시도하면 **403 Forbidden** 응답을 받는지 확인합니다.
    - 이메일 인증 완료 후 다시 로그인을 시도하면 성공하는지 확인합니다.

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [x] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.  

이번 PR은 애플리케이션의 안정성과 보안을 크게 개선하는 두 가지 중요한 리팩토링을 포함합니다.

- **연도 정책**: `TimeConfig`를 중심으로 여러 파일에 걸쳐 일관성이 적용되었는지 확인 부탁드립니다.
- **인증 로직**: `AuthController`의 `refreshToken` 메서드가 HttpOnly 쿠키를 우선적으로 사용하도록 변경된 부분과, 로컬/소셜 계정의 가입/로그인 플로우가 명확히 분리되었는지 집중적으로 검토해주시면 감사하겠습니다.