### PR TITLE
[Feat]: 일정 및 일기 목록 조회 API 엔드포인트 추가 (#92)

### DIFF
--- a/src/main/java/com/tropical/backend/diary/controller/DiaryController.java
+++ b/src/main/java/com/tropical/backend/diary/controller/DiaryController.java
@@ -14,6 +14,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
  * 일기 관리 컨트롤러
  *
@@ -58,6 +63,135 @@ public class DiaryController {
         DiaryResponse response = convertToResponse(savedDiary);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 사용자의 모든 일기 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<DiaryResponse>> getAllDiaries(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<Diary> diaries = diaryService.getDiariesByUserId(userId);
+
+        List<DiaryResponse> responses = diaries.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 특정 날짜의 일기 조회
+     */
+    @GetMapping("/date/{date}")
+    public ResponseEntity<DiaryResponse> getDiaryByDate(
+            @PathVariable LocalDate date,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        Optional<Diary> diary = diaryService.getDiaryByDate(userId, date);
+
+        if (diary.isPresent()) {
+            DiaryResponse response = convertToResponse(diary.get());
+            return ResponseEntity.ok(response);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * 특정 월의 일기 조회
+     */
+    @GetMapping("/month/{year}/{month}")
+    public ResponseEntity<List<DiaryResponse>> getDiariesByMonth(
+            @PathVariable int year,
+            @PathVariable int month,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<Diary> diaries = diaryService.getDiariesByMonth(userId, year, month);
+
+        List<DiaryResponse> responses = diaries.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 감정별 일기 조회
+     */
+    @GetMapping("/emotion/{emotion}")
+    public ResponseEntity<List<DiaryResponse>> getDiariesByEmotion(
+            @PathVariable String emotion,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<Diary> diaries = diaryService.getDiariesByEmotion(userId, emotion);
+
+        List<DiaryResponse> responses = diaries.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 날씨별 일기 조회
+     */
+    @GetMapping("/weather/{weather}")
+    public ResponseEntity<List<DiaryResponse>> getDiariesByWeather(
+            @PathVariable String weather,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<Diary> diaries = diaryService.getDiariesByWeather(userId, weather);
+
+        List<DiaryResponse> responses = diaries.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 특정 날짜에 일기 존재 여부 확인
+     */
+    @GetMapping("/exists/{date}")
+    public ResponseEntity<Boolean> checkDiaryExists(
+            @PathVariable LocalDate date,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        boolean exists = diaryService.existsByDate(userId, date);
+
+        return ResponseEntity.ok(exists);
     }
 
     /**

--- a/src/main/java/com/tropical/backend/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/tropical/backend/schedule/controller/ScheduleController.java
@@ -14,6 +14,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * 일정 관리 컨트롤러
  *
@@ -60,6 +64,72 @@ public class ScheduleController {
         ScheduleResponse response = convertToResponse(savedSchedule);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 사용자의 모든 일정 조회
+     */
+    @GetMapping
+    public ResponseEntity<List<ScheduleResponse>> getAllSchedules(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<Schedule> schedules = scheduleService.getSchedulesByUserId(userId);
+
+        List<ScheduleResponse> responses = schedules.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 특정 날짜의 일정 조회
+     */
+    @GetMapping("/date/{date}")
+    public ResponseEntity<List<ScheduleResponse>> getSchedulesByDate(
+            @PathVariable LocalDate date,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<Schedule> schedules = scheduleService.getSchedulesByDate(userId, date);
+
+        List<ScheduleResponse> responses = schedules.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 특정 월의 일정 조회
+     */
+    @GetMapping("/month/{year}/{month}")
+    public ResponseEntity<List<ScheduleResponse>> getSchedulesByMonth(
+            @PathVariable int year,
+            @PathVariable int month,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("인증된 사용자 정보가 필요합니다");
+        }
+
+        Long userId = Long.valueOf(userDetails.getUsername());
+        List<Schedule> schedules = scheduleService.getSchedulesByMonth(userId, year, month);
+
+        List<ScheduleResponse> responses = schedules.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
     }
 
     /**


### PR DESCRIPTION
## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [x] 버그 수정 (Bugfix)
- [x] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

프론트엔드에서 일정과 일기 데이터 목록을 불러오지 못하는 문제를 해결하기 위해, **ScheduleController와 DiaryController에 누락된 목록 조회 API 엔드포인트들을 추가**했습니다. 

기존에 서비스 레이어에는 목록 조회 메서드들이 구현되어 있었으나, 컨트롤러에서 이를 활용하는 엔드포인트가 없어서 프론트엔드가 데이터에 접근할 수 없었던 상황을 해결했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.  
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #92
- Fixes # 프론트엔드 데이터 로딩 문제

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

### ScheduleController.java 변경사항
- **`GET /api/v1/schedules`** - 사용자의 모든 일정 조회 엔드포인트 추가
- **`GET /api/v1/schedules/date/{date}`** - 특정 날짜의 일정 조회 엔드포인트 추가
- **`GET /api/v1/schedules/month/{year}/{month}`** - 특정 월의 일정 조회 엔드포인트 추가
- 기존 서비스 메서드(`getSchedulesByUserId`, `getSchedulesByDate`, `getSchedulesByMonth`) 활용
- 사용자 인증 및 권한 검증 로직 포함
- Entity → ScheduleResponse DTO 변환 로직 적용

### DiaryController.java 변경사항
- **`GET /api/v1/diaries`** - 사용자의 모든 일기 조회 엔드포인트 추가
- **`GET /api/v1/diaries/date/{date}`** - 특정 날짜의 일기 조회 엔드포인트 추가
- **`GET /api/v1/diaries/month/{year}/{month}`** - 특정 월의 일기 조회 엔드포인트 추가
- **`GET /api/v1/diaries/emotion/{emotion}`** - 감정별 일기 조회 엔드포인트 추가
- **`GET /api/v1/diaries/weather/{weather}`** - 날씨별 일기 조회 엔드포인트 추가
- **`GET /api/v1/diaries/exists/{date}`** - 특정 날짜 일기 존재 여부 확인 엔드포인트 추가
- 기존 서비스 메서드들을 모두 활용하여 컨트롤러 레이어에서 API 제공
- Optional 타입 처리 및 적절한 HTTP 상태 코드 반환 (200 OK, 404 Not Found)

### 공통 개선사항
- 모든 엔드포인트에 `@AuthenticationPrincipal UserDetails` 적용하여 사용자 인증 처리
- Stream API를 사용한 Entity List → Response DTO List 변환
- 일관된 에러 처리 및 응답 형식

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

이 작업은 백엔드 API 추가이므로 UI 변경사항은 없습니다. 하지만 이제 프론트엔드에서 다음과 같은 API 호출이 가능해집니다:

```javascript
// 예시: 사용자의 모든 일정 조회
fetch('/api/v1/schedules', {
  headers: { 'Authorization': 'Bearer ' + token }
})

// 예시: 특정 월의 일기 조회
fetch('/api/v1/diaries/month/2025/9', {
  headers: { 'Authorization': 'Bearer ' + token }
})
```

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

1. **브랜치 체크아웃**
   ```bash
   git fetch origin
   git checkout fix/controller-service-integration
   ```

2. **애플리케이션 실행**
   ```bash
   ./gradlew bootRun
   ```

3. **API 테스트 (Postman 또는 curl 사용)**
   
   **사전 조건**: 유효한 JWT 토큰 필요 (로그인 후 획득)
   
   ```bash
   # 1. 모든 일정 조회 테스트
   curl -H "Authorization: Bearer YOUR_JWT_TOKEN" \
        http://localhost:8080/api/v1/schedules
   
   # 2. 특정 날짜 일정 조회 테스트
   curl -H "Authorization: Bearer YOUR_JWT_TOKEN" \
        http://localhost:8080/api/v1/schedules/date/2025-09-22
   
   # 3. 모든 일기 조회 테스트
   curl -H "Authorization: Bearer YOUR_JWT_TOKEN" \
        http://localhost:8080/api/v1/diaries
   
   # 4. 월별 일기 조회 테스트
   curl -H "Authorization: Bearer YOUR_JWT_TOKEN" \
        http://localhost:8080/api/v1/diaries/month/2025/9
   
   # 5. 일기 존재 여부 확인 테스트
   curl -H "Authorization: Bearer YOUR_JWT_TOKEN" \
        http://localhost:8080/api/v1/diaries/exists/2025-09-22
   ```

4. **응답 확인사항**
   - 인증된 사용자의 데이터만 반환되는지 확인
   - 빈 배열이라도 200 OK 상태로 응답하는지 확인
   - 날짜별 일기 조회 시 데이터가 없으면 404 Not Found 반환하는지 확인
   - JSON 응답 형식이 기존 개별 조회 API와 일치하는지 확인

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [x] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.  
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

### 주요 검토 포인트:

1. **API 엔드포인트 경로 충돌 여부 확인**
   - 새로 추가된 경로들이 기존 `/{id}` 패턴과 충돌하지 않는지 확인 필요
   - Spring의 경로 매핑 우선순위가 올바르게 작동하는지 검증

2. **인증 및 권한 검증 로직**
   - 모든 엔드포인트에서 사용자 인증이 올바르게 처리되는지 확인
   - 다른 사용자의 데이터가 노출되지 않는지 보안 검증

3. **응답 형식 일관성**
   - 기존 개별 조회 API와 동일한 DTO 구조를 사용하는지 확인
   - 에러 응답 처리가 일관되게 구현되었는지 검증

4. **성능 고려사항**
   - 목록 조회 시 페이징 처리가 필요한지 향후 검토 필요
   - 현재는 전체 데이터를 반환하므로 데이터량 증가 시 성능 이슈 가능성

### 참고사항:
- 기존 서비스 레이어의 메서드들을 그대로 활용하여 비즈니스 로직 변경 없음
- 새로운 의존성 추가 없이 기존 프레임워크 기능만 사용
- 향후 페이징, 정렬, 필터링 기능 추가 시 확장 용이한 구조로 구현
